### PR TITLE
feat: remove all deps to Application instance

### DIFF
--- a/packages/application/lib/extension.ts
+++ b/packages/application/lib/extension.ts
@@ -1,16 +1,12 @@
 import { ExtensionApplication, Extra } from './types'
 
-export abstract class BaseExtension<
-  Context extends Extra = {},
-  E extends Extra = {},
-> {
+export abstract class BaseExtension<E extends Extra = {}> {
   readonly _!: {} & E
   readonly application!: ExtensionApplication
 
   abstract name: string
 
   initialize?(): void
-  context?(): Context
 
   assign(application: this['application']) {
     // @ts-expect-error

--- a/packages/application/lib/transport.ts
+++ b/packages/application/lib/transport.ts
@@ -3,15 +3,13 @@ import { randomUUID } from 'node:crypto'
 import { Event } from './events'
 import { BaseExtension } from './extension'
 import { Subscription } from './subscription'
-import { Extra } from './types'
 
 export interface BaseTransportData {
   transport: string
 }
 export abstract class BaseTransport<
-  Context extends Extra = {},
   Connection extends BaseTransportConnection = BaseTransportConnection,
-> extends BaseExtension<Context, { connection: Connection }> {
+> extends BaseExtension<{ connection: Connection }> {
   abstract start(): any
   abstract stop(): any
 

--- a/packages/application/lib/types.ts
+++ b/packages/application/lib/types.ts
@@ -71,7 +71,7 @@ export type Command = (
 
 export type ConnectionFn<T = any, C = any> = (transportData: T) => Async<C>
 
-export type FilterFn<T extends ErrorClass> = (
+export type FilterFn<T extends ErrorClass = ErrorClass> = (
   error: InstanceType<T>,
 ) => Async<Error>
 
@@ -97,11 +97,12 @@ export type Middleware<App extends AnyApplication = AnyApplication> = Provider<
 
 export type ConnectionProvider<T, C> = Provider<ConnectionFn<T, C>>
 
-export type AnyApplication = Application<any, any, any, any, any, any>
-export type AnyProvider = Provider<any, any, any, any, any, any, any>
-export type AnyProcedure = Procedure<any, any, any, any, any>
-export type AnyTask = Task<any, any, any, any>
-export type AnyEvent = Event<any, any, any, any>
+export type AnyApplication = Application<any, any, any, any, any>
+
+export type AnyProvider = Provider<any, any, any>
+export type AnyProcedure = Procedure<any, any, any, any>
+export type AnyTask = Task<any, any, any>
+export type AnyEvent = Event<any, any, any>
 
 export type MiddlewareContext<App extends AnyApplication = AnyApplication> = {
   connection: App['_']['connection']
@@ -172,10 +173,6 @@ export type Scalars = Primitive | Primitive[]
 
 export type GlobalContext = {
   logger: Logger
-  execute: <T extends Task>(
-    task: T,
-    ...args: OmitFirstItem<Parameters<T['handler']>>
-  ) => TaskExecution<Awaited<ReturnType<T['handler']>>>
 }
 
 export type Filters = Map<ErrorClass, Filter<ErrorClass>>
@@ -186,6 +183,22 @@ export type Commands<T extends string | symbol = string | symbol> = Map<
   Map<string, Command>
 >
 export type Hooks = Map<string, Set<(...args: any[]) => any>>
+
+export type CallFn = <P extends Procedure>(
+  procedure: P,
+  ...args: P['input'] extends unknown ? [] : [InferSchemaOutput<P['input']>]
+) => Promise<
+  Awaited<
+    P['output'] extends unknown
+      ? ReturnType<P['handler']>
+      : InferSchemaOutput<P['output']>
+  >
+>
+
+export type ExecuteFn = <T extends Task>(
+  task: T,
+  ...args: OmitFirstItem<Parameters<T['handler']>>
+) => TaskExecution<Awaited<ReturnType<T['handler']>>>
 
 export type Merge<
   T1 extends Record<string, any>,

--- a/packages/application/test/_utils.ts
+++ b/packages/application/test/_utils.ts
@@ -1,6 +1,7 @@
 import { BaseParser, Procedure } from '@/api'
 import { Application, ApplicationOptions } from '@/application'
 import { Event } from '@/events'
+import { createLogger } from '@/logger'
 import { BaseTaskRunner, Task } from '@/tasks'
 import { BaseTransport, BaseTransportConnection } from '@/transport'
 import { WorkerType } from '@/types'
@@ -57,20 +58,28 @@ export class TestTransport extends BaseTransport {
   }
 }
 
-export const defaultTimeout = 1000
+export const testDefaultTimeout = 1000
+
+export const testLogger = () =>
+  createLogger(
+    {
+      pinoOptions: { enabled: false },
+    },
+    'test',
+  )
 
 export const testApp = (options: Partial<ApplicationOptions> = {}) =>
   new Application(
     Object.assign(
       {
         type: WorkerType.Api,
-        events: { timeout: defaultTimeout },
+        events: { timeout: testDefaultTimeout },
         loaders: [],
-        procedures: {
-          timeout: defaultTimeout,
+        api: {
+          timeout: testDefaultTimeout,
         },
         tasks: {
-          timeout: defaultTimeout,
+          timeout: testDefaultTimeout,
         },
         logging: {
           pinoOptions: { enabled: false },

--- a/packages/application/test/events.spec.ts
+++ b/packages/application/test/events.spec.ts
@@ -1,5 +1,3 @@
-// events
-
 import { Application } from '@/application'
 import { Event, EventManager } from '@/events'
 import { BaseTransportConnection } from '@/transport'

--- a/packages/application/test/extension.spec.ts
+++ b/packages/application/test/extension.spec.ts
@@ -2,7 +2,7 @@ import { Application } from '@/application'
 import { Provider } from '@/container'
 import { BaseExtension } from '@/extension'
 import { Registry } from '@/registry'
-import { WorkerType } from '@/types'
+import { FilterFn, MiddlewareFn, WorkerType } from '@/types'
 import { noop } from '@/utils/functions'
 import { testApp } from './_utils'
 
@@ -32,13 +32,11 @@ describe.sequential('Extension', () => {
     const extension = new TestExtension()
     const app = testApp()
     const initSpy = vi.spyOn(extension, 'initialize')
-    const contextSpy = vi.spyOn(extension, 'context')
     app.registerExtensions({ [alias]: extension })
     expect(app.extensions).toHaveProperty(alias, extension)
     expect(extension.application).toBeDefined()
     await app.initialize()
     expect(initSpy).toHaveBeenCalledOnce()
-    expect(contextSpy).toHaveBeenCalledOnce()
   })
 
   it('should assign an app', async () => {
@@ -67,13 +65,13 @@ describe.sequential('Extension', () => {
   })
 
   it('should register filters', async () => {
-    const filter = new Provider().withValue(() => new Error())
+    const filter = new Provider().withValue((() => new Error()) as FilterFn)
     extension.application.registry.registerFilter(Error, filter)
     expect(app.registry.filters.get(Error)).toBe(filter)
   })
 
   it('should register middleware', async () => {
-    const middleware = new Provider().withValue(noop)
+    const middleware = new Provider().withValue(noop as MiddlewareFn)
     extension.application.registry.registerMiddleware(middleware)
     expect(app.registry.middlewares.has(middleware)).toBe(true)
   })

--- a/packages/application/test/loaders/module.spec.ts
+++ b/packages/application/test/loaders/module.spec.ts
@@ -58,46 +58,4 @@ describe.sequential('Loaders -> Module', () => {
       }
     })
   }
-
-  // describe('Events', () => {
-  //   it('should load event', async () => {
-  //     for (const [module, key, exportName, singleFile] of keys) {
-  //       const path = join(
-  //         root,
-  //         module,
-  //         `${singleFile ? join(loader.options.events, key) : key}.ts`,
-  //       )
-  //       const name = [module, key].join('/')
-  //       expect(app.registry.events.has(name)).toBe(true)
-  //       expect(app.registry.events.get(name)?.path).toBe(path)
-  //       expect(app.registry.events.get(name)?.exportName).toBe(
-  //         `["${exportName}"]`,
-  //       )
-  //       expect(app.registry.events.get(name)?.module).toBe(
-  //         await import(path).then((m) => m[exportName]),
-  //       )
-  //     }
-  //   })
-  // })
-
-  // describe('Procedures', () => {
-  //   it('should load procedure', async () => {
-  //     for (const [module, key, exportName, singleFile] of keys) {
-  //       const path = join(
-  //         root,
-  //         module,
-  //         `${singleFile ? join(loader.options.procedures, key) : key}.ts`,
-  //       )
-  //       const name = [module, key].join('/')
-  //       expect(app.registry.procedures.has(name)).toBe(true)
-  //       expect(app.registry.procedures.get(name)?.path).toBe(path)
-  //       expect(app.registry.procedures.get(name)?.exportName).toBe(
-  //         `["${exportName}"]`,
-  //       )
-  //       expect(app.registry.procedures.get(name)?.module).toBe(
-  //         await import(path).then((m) => m[exportName]),
-  //       )
-  //     }
-  //   })
-  // })
 })

--- a/packages/application/test/registry.spec.ts
+++ b/packages/application/test/registry.spec.ts
@@ -1,9 +1,8 @@
-import { Application } from '@/application'
 import { Provider } from '@/container'
 import { APP_COMMAND, BaseCustomLoader, Registry } from '@/registry'
 import { Scope } from '@/types'
 import { noop } from '@/utils/functions'
-import { testApp, testEvent, testProcedure, testTask } from './_utils'
+import { testEvent, testLogger, testProcedure, testTask } from './_utils'
 
 class TestCustomLoader implements BaseCustomLoader {
   async load() {
@@ -37,116 +36,93 @@ class TestCustomLoader implements BaseCustomLoader {
   }
 }
 
-describe.sequential('Registry', () => {
-  let app: Application
+describe(() => {
+  const logger = testLogger()
   let registry: Registry
 
   beforeEach(() => {
-    app = testApp({ loaders: [new TestCustomLoader()] })
-    registry = app.registry
+    registry = new Registry({ logger }, [new TestCustomLoader()])
   })
 
-  it('should be a loader', () => {
-    expect(registry).toBeDefined()
-    expect(registry).toBeInstanceOf(Registry)
+  describe.sequential('Registry', () => {
+    it('should be a loader', () => {
+      expect(registry).toBeDefined()
+      expect(registry).toBeInstanceOf(Registry)
+    })
+
+    it('should load', async () => {
+      await registry.load()
+      expect(registry.procedures.has('test')).toBe(true)
+      expect(registry.tasks.has('test')).toBe(true)
+      expect(registry.events.has('test')).toBe(true)
+    })
+
+    it('should registry "task" command', () => {
+      const taskCommand = registry.commands.get(APP_COMMAND)?.get('task')
+      expect(taskCommand).toBeDefined()
+      expect(taskCommand).toBeTypeOf('function')
+    })
   })
 
-  it('should load', async () => {
-    await registry.load()
-    expect(registry.procedures.has('test')).toBe(true)
-    expect(registry.tasks.has('test')).toBe(true)
-    expect(registry.events.has('test')).toBe(true)
+  describe.sequential('Registry -> Procedure', () => {
+    it('should register procedure', async () => {
+      const procedure = testProcedure().withHandler(noop)
+      registry.registerProcedure(procedure.name, procedure)
+      expect(registry.procedure('test')).toBe(procedure)
+    })
+
+    it('should fail register procedure without handler', async () => {
+      const procedure = testProcedure()
+      expect(() =>
+        registry.registerProcedure(procedure.name, procedure),
+      ).toThrow()
+    })
+
+    it('should fail register duplicate procedure', async () => {
+      const procedure = testProcedure().withHandler(noop)
+      registry.registerProcedure(procedure.name, procedure)
+      expect(() =>
+        registry.registerProcedure(procedure.name, procedure),
+      ).toThrow()
+    })
   })
 
-  it('should registry "task" command', () => {
-    const taskCommand = registry.commands.get(APP_COMMAND)?.get('task')
-    expect(taskCommand).toBeDefined()
-    expect(taskCommand).toBeTypeOf('function')
-  })
-})
+  describe.sequential('Registry -> Task', () => {
+    it('should register task', async () => {
+      const task = testTask().withHandler(noop)
+      registry.registerTask(task.name, task)
+      expect(registry.task(task.name)).toBe(task)
+    })
 
-describe.sequential('Registry -> Procedure', () => {
-  let app: Application
-  let registry: Registry
+    it('should fail register task without handler', async () => {
+      const task = testTask()
+      expect(() => registry.registerTask(task.name, task)).toThrow()
+    })
 
-  beforeEach(() => {
-    app = testApp()
-    registry = app.registry
-  })
+    it('should fail register duplicate task', async () => {
+      const task = testTask().withHandler(noop)
+      registry.registerTask(task.name, task)
+      expect(() => registry.registerTask(task.name, task)).toThrow()
+    })
 
-  it('should register procedure', async () => {
-    const procedure = testProcedure().withHandler(noop)
-    registry.registerProcedure(procedure.name, procedure)
-    expect(registry.procedure('test')).toBe(procedure)
-  })
-
-  it('should fail register procedure without handler', async () => {
-    const procedure = testProcedure()
-    expect(() =>
-      registry.registerProcedure(procedure.name, procedure),
-    ).toThrow()
+    it('should fail register task with non-global dependencies', async () => {
+      const provider = new Provider().withScope(Scope.Connection)
+      const task = testTask().withHandler(noop).withDependencies({ provider })
+      expect(() => registry.registerTask(task.name, task)).toThrow()
+    })
   })
 
-  it('should fail register duplicate procedure', async () => {
-    const procedure = testProcedure().withHandler(noop)
-    registry.registerProcedure(procedure.name, procedure)
-    expect(() =>
-      registry.registerProcedure(procedure.name, procedure),
-    ).toThrow()
-  })
-})
+  describe.sequential('Registry -> Event', () => {
+    it('should register event', async () => {
+      const event = testEvent()
+      registry.registerEvent(event.name, event)
+      expect(registry.event(event.name)).toBe(event)
+    })
 
-describe.sequential('Registry -> Task', () => {
-  let app: Application
-  let registry: Registry
-
-  beforeEach(() => {
-    app = testApp()
-    registry = app.registry
-  })
-
-  it('should register task', async () => {
-    const task = testTask().withHandler(noop)
-    registry.registerTask(task.name, task)
-    expect(registry.task(task.name)).toBe(task)
-  })
-
-  it('should fail register task without handler', async () => {
-    const task = testTask()
-    expect(() => registry.registerTask(task.name, task)).toThrow()
-  })
-
-  it('should fail register duplicate task', async () => {
-    const task = testTask().withHandler(noop)
-    registry.registerTask(task.name, task)
-    expect(() => registry.registerTask(task.name, task)).toThrow()
-  })
-
-  it('should fail register task with non-global dependencies', async () => {
-    const provider = new Provider().withScope(Scope.Connection)
-    const task = testTask().withHandler(noop).withDependencies({ provider })
-    expect(() => registry.registerTask(task.name, task)).toThrow()
-  })
-})
-
-describe.sequential('Registry -> Event', () => {
-  let app: Application
-  let registry: Registry
-
-  beforeEach(() => {
-    app = testApp()
-    registry = app.registry
-  })
-
-  it('should register event', async () => {
-    const event = testEvent()
-    registry.registerEvent(event.name, event)
-    expect(registry.event(event.name)).toBe(event)
-  })
-
-  it('should fail register duplicate event', async () => {
-    const event = testEvent()
-    registry.registerEvent(event.name, event)
-    expect(() => registry.registerEvent(event.name, event)).toThrow()
+    it('should fail register duplicate event', async () => {
+      const event = testEvent()
+      registry.registerEvent(event.name, event)
+      expect(() => registry.registerEvent(event.name, event)).toThrow()
+    })
   })
 })

--- a/packages/application/test/transport.spec.ts
+++ b/packages/application/test/transport.spec.ts
@@ -1,76 +1,76 @@
-// import { Application } from '@/application'
-// import { TestTransport, testApp, testConnection, testEvent } from './_utils'
+import { Application } from '@/application'
+import { TestTransport, testApp, testConnection, testEvent } from './_utils'
 
-// describe.sequential('Transport', () => {
-//   let app: Application<{ test: TestTransport }>
-//   let transport: TestTransport
+describe.sequential('Transport', () => {
+  let app: Application<{ test: TestTransport }>
+  let transport: TestTransport
 
-//   beforeEach(async () => {
-//     transport = new TestTransport()
-//     app = testApp().registerTransports({ test: transport })
-//     await app.initialize()
-//   })
+  beforeEach(async () => {
+    transport = new TestTransport()
+    app = testApp().registerTransports({ test: transport })
+    await app.initialize()
+  })
 
-//   it('should start and stop', async () => {
-//     const startSpy = vi.spyOn(transport, 'start')
-//     const stopSpy = vi.spyOn(transport, 'stop')
-//     await app.start()
-//     expect(startSpy).toHaveBeenCalledOnce()
-//     await app.stop()
-//     expect(stopSpy).toHaveBeenCalledOnce()
-//   })
+  it('should start and stop', async () => {
+    const startSpy = vi.spyOn(transport, 'start')
+    const stopSpy = vi.spyOn(transport, 'stop')
+    await app.start()
+    expect(startSpy).toHaveBeenCalledOnce()
+    await app.stop()
+    expect(stopSpy).toHaveBeenCalledOnce()
+  })
 
-//   it('should add connection', async () => {
-//     transport.addConnection(testConnection())
-//     expect(app.connections.size).toBe(1)
-//   })
+  it('should add connection', async () => {
+    transport.addConnection(testConnection())
+    expect(app.connections.size).toBe(1)
+  })
 
-//   it('should remove connection', async () => {
-//     const connection = testConnection()
-//     transport.addConnection(connection)
-//     expect(app.connections.size).toBe(1)
-//     transport.removeConnection(connection)
-//     expect(app.connections.size).toBe(0)
-//   })
+  it('should remove connection', async () => {
+    const connection = testConnection()
+    transport.addConnection(connection)
+    expect(app.connections.size).toBe(1)
+    transport.removeConnection(connection)
+    expect(app.connections.size).toBe(0)
+  })
 
-//   it('should remove connection by id', async () => {
-//     const connection = testConnection()
-//     transport.addConnection(connection)
-//     expect(app.connections.size).toBe(1)
-//     transport.removeConnection(connection.id)
-//     expect(app.connections.size).toBe(0)
-//   })
+  it('should remove connection by id', async () => {
+    const connection = testConnection()
+    transport.addConnection(connection)
+    expect(app.connections.size).toBe(1)
+    transport.removeConnection(connection.id)
+    expect(app.connections.size).toBe(0)
+  })
 
-//   it('should get connection', async () => {
-//     const connection = testConnection()
-//     transport.addConnection(connection)
-//     expect(transport.getConnection(connection.id)).toBe(connection)
-//   })
+  it('should get connection', async () => {
+    const connection = testConnection()
+    transport.addConnection(connection)
+    expect(transport.getConnection(connection.id)).toBe(connection)
+  })
 
-//   it('should check connection', async () => {
-//     const connection = testConnection()
-//     transport.addConnection(connection)
-//     expect(transport.hasConnection(connection)).toBe(true)
-//   })
-// })
+  it('should check connection', async () => {
+    const connection = testConnection()
+    transport.addConnection(connection)
+    expect(transport.hasConnection(connection)).toBe(true)
+  })
+})
 
-// describe.sequential('Transport connection', () => {
-//   let app: Application<{ test: TestTransport }>
-//   let transport: TestTransport
+describe.sequential('Transport connection', () => {
+  let app: Application<{ test: TestTransport }>
+  let transport: TestTransport
 
-//   beforeEach(async () => {
-//     transport = new TestTransport()
-//     app = testApp().registerTransports({ test: transport })
-//     await app.initialize()
-//   })
+  beforeEach(async () => {
+    transport = new TestTransport()
+    app = testApp().registerTransports({ test: transport })
+    await app.initialize()
+  })
 
-//   it('should send event', async () => {
-//     const connection = testConnection()
-//     transport.addConnection(connection)
-//     const event = testEvent()
-//     const payload = { some: 'data' }
-//     const sendSpy = vi.spyOn(connection, 'sendEvent' as any)
-//     connection.send(event, payload)
-//     expect(sendSpy).toHaveBeenCalledWith(event.name, payload)
-//   })
-// })
+  it('should send event', async () => {
+    const connection = testConnection()
+    transport.addConnection(connection)
+    const event = testEvent()
+    const payload = { some: 'data' }
+    const sendSpy = vi.spyOn(connection, 'sendEvent' as any)
+    connection.send(event, payload)
+    expect(sendSpy).toHaveBeenCalledWith(event.name, payload)
+  })
+})

--- a/packages/transport-websockets/lib/server.ts
+++ b/packages/transport-websockets/lib/server.ts
@@ -262,7 +262,6 @@ export class WebsocketsTransportServer extends BaseHttpTransportServer {
         const container = this.container.createScope(Scope.Connection)
 
         try {
-          // const connectionData = await this.getConnectionData(transportData)
           const streams = {
             up: new Map(),
             down: new Map(),
@@ -273,7 +272,6 @@ export class WebsocketsTransportServer extends BaseHttpTransportServer {
             id: randomUUID(),
             streams,
             container,
-            // connectionData,
             transportData,
             subscriptions: new Map(),
           }
@@ -591,6 +589,7 @@ export class WebsocketsTransportServer extends BaseHttpTransportServer {
       // It doesn't support streams and bidi communication anyway,
       // so any of usefull stuff is not available
       // this.transport.addConnection(connection)
+
       const procedure = this.api.find(procedureName)
       const response = await this.handleRPC(
         connection,

--- a/packages/transport-websockets/lib/transport.ts
+++ b/packages/transport-websockets/lib/transport.ts
@@ -4,16 +4,11 @@ import {
   WebsocketsTransportConnection,
 } from './connection'
 import { WebsocketsTransportServer } from './server'
-import {
-  HttpTransportApplicationContext,
-  WebsocketsTransportApplicationContext,
-  WebsocketsTransportOptions,
-} from './types'
+import { WebsocketsTransportOptions } from './types'
 
 export class WebsocketsTransport<
   Options extends WebsocketsTransportOptions = WebsocketsTransportOptions,
 > extends BaseTransport<
-  HttpTransportApplicationContext & WebsocketsTransportApplicationContext,
   HttpTransportConnection | WebsocketsTransportConnection
 > {
   name = 'Websockets Transport'

--- a/packages/transport-websockets/lib/types.ts
+++ b/packages/transport-websockets/lib/types.ts
@@ -29,8 +29,6 @@ export type HttpTransportData = {
   method: HttpTransportMethod
 }
 
-export type HttpTransportApplicationContext = {}
-
 export type Headers = Record<string, string>
 export type Req = HttpRequest
 export type Res = HttpResponse
@@ -66,5 +64,3 @@ export type WebsocketsTransportData = {
   proxyRemoteAddress: string
   remoteAddress: string
 }
-
-export type WebsocketsTransportApplicationContext = {}


### PR DESCRIPTION
Remove all dependencies to Application instance: `logger`, `eventManager`, `call`, `execute`, `connection` are now resolved as on-demand providers